### PR TITLE
build: :pushpin: to indicate to install package from GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Depends:
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    CMAverse,
+    CMAverse (>= 0.1.0),
     DiagrammeR,
     DiagrammeRsvg,
     dplyr,
@@ -18,3 +18,5 @@ Imports:
     mediation,
     readr,
     rmarkdown
+Remotes:  
+    BS1125/CMAverse


### PR DESCRIPTION
When you use a package that is installed from GitHub (the CMAverse), you need to tell R where to install it from since R assumes CRAN. Using `use_dev_package()` correctly updates the DESCRIPTION file with that information.